### PR TITLE
PRにコメントを書き込める権限を付与

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -34,7 +34,8 @@ jobs:
     needs: take-base-screenshots
     runs-on: ubuntu-latest
     permissions:
-      pull_request: write
+      contents: read
+      issues: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -33,6 +33,8 @@ jobs:
     timeout-minutes: 15
     needs: take-base-screenshots
     runs-on: ubuntu-latest
+    permissions:
+      pull_request: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6


### PR DESCRIPTION
dependabotの権限がreadであり、VRTレポートコメントの書き込みに失敗するため