### PR TITLE
PRへのコメント処理を別のワークフローに分ける

### DIFF
--- a/.github/workflows/comment-vrt-report.yml
+++ b/.github/workflows/comment-vrt-report.yml
@@ -4,12 +4,13 @@ on:
     workflows: ["VRT"]
     types: [completed]
 jobs:
-  comment-vr-report:
+  comment-vrt-report:
     timeout-minutes: 15
     runs-on: ubuntu-latest
     permissions:
       issues: write
       contents: read
+      actions: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
       - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
@@ -19,16 +20,27 @@ jobs:
           cache: "pnpm"
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
-      - name: Download playwright report
+      - name: Download playwright results
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
-          name: playwright-report
-          path: playwright-report/
+          run-id: ${{ github.event.workflow_run.id }}
+          name: playwright-results
+          path: ${{ github.workspace}}
       - name: Comment PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:
           VRT_REPORT_PATH: ${{ github.workspace}}/playwright-results.json
         with:
           script: |
+            const pr = context.payload.workflow_run.pull_requests?.[0];
+            if (!pr) {
+              core.info("workflow_run に紐づく PR が見つからないためコメントをスキップします");
+              return;
+            }
+            const patchedContext = {
+              ...context,
+              issue: { ...context.issue, number: pr.number },
+              runId: context.payload.workflow_run.id,
+            };
             const script = await import('${{ github.workspace }}/scripts/vrt-comment-pr.js');
-            await script.default({ github, core, context });
+            await script.default({ github, core, context: patchedContext });

--- a/.github/workflows/comment-vrt-report.yml
+++ b/.github/workflows/comment-vrt-report.yml
@@ -1,0 +1,34 @@
+name: Comment VRT Report
+on:
+  workflow_run:
+    workflows: ["VRT"]
+    types: [completed]
+jobs:
+  comment-vr-report:
+    timeout-minutes: 15
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v4
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: "pnpm"
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+      - name: Download playwright report
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
+        with:
+          name: playwright-report
+          path: playwright-report/
+      - name: Comment PR
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        env:
+          VRT_REPORT_PATH: ${{ github.workspace}}/playwright-results.json
+        with:
+          script: |
+            const script = await import('${{ github.workspace }}/scripts/vrt-comment-pr.js');
+            await script.default({ github, core, context });

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -61,3 +61,9 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 1
+      - name: Upload playwright result
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: playwright-results
+          path: ${{ github.workspace}}/playwright-results.json
+          retention-days: 1

--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -61,12 +61,3 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 1
-
-      - name: Comment PR
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
-        env:
-          VRT_REPORT_PATH: ${{ github.workspace}}/playwright-results.json
-        with:
-          script: |
-            const script = await import('${{ github.workspace }}/scripts/vrt-comment-pr.js');
-            await script.default({ github, core, context });


### PR DESCRIPTION
dependabotの権限がreadであり、pull_request_targetにするのはリスクが有るため、workflowをわける。workflow_runはベースリポジトリ権限で実行するためコメントができる