### PR TITLE
Github Actions debug用のPR

### DIFF
--- a/.github/workflows/comment-vrt-report.yml
+++ b/.github/workflows/comment-vrt-report.yml
@@ -26,6 +26,20 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           name: playwright-results
           path: ${{ github.workspace}}
+      - uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
+        with:
+          script: |
+            const runId = context.payload.workflow_run.id;
+
+            console.log("runId =", runId);
+            console.log("workflow =", context.payload.workflow_run.name);
+
+            const result = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: runId,
+            });
+            console.log(JSON.stringify(result.data, null, 2));
       - name: Comment PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:


### PR DESCRIPTION
consoleに情報を出力する

dependabot[bot]が作成したPRでGithubへのコメントが `Resource not accessible by integration` で失敗する。
permission設定やベースリポジトリの設定など確認する。
また、VRTのレポートをartifactにuploadし、PRへコメントするworkflowでdownloadしているが、 `Unable to download artifact(s)` になる問題の調査もする。artifactのnameは一致しているはず…

マージしないとworkflowが動かないのでマージして確かめます