### PR TITLE
github tokenを明示的に渡す

### DIFF
--- a/.github/workflows/comment-vrt-report.yml
+++ b/.github/workflows/comment-vrt-report.yml
@@ -55,6 +55,7 @@ jobs:
           run-id: ${{ github.event.workflow_run.id }}
           name: playwright-results
           path: ${{ github.workspace}}
+          github-token: ${{ github.token }}
       - name: Comment PR
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9
         env:


### PR DESCRIPTION
actions/download-artifactはgithub tokenを渡さないと他のworkflowでアップロードされたartifactsが取得できない